### PR TITLE
Print and optionally write offsets to duck_config

### DIFF
--- a/scripts/find_soft_offsets.py
+++ b/scripts/find_soft_offsets.py
@@ -5,6 +5,11 @@ Find the offsets to set in self.joints_offsets in hwi_feetech_pwm_control.py
 from mini_bdx_runtime.rustypot_position_hwi import HWI
 from mini_bdx_runtime.duck_config import DuckConfig
 import time
+import json
+import os
+
+HOME_DIR = os.path.expanduser("~")
+DUCK_CONFIG_PATH = os.path.join(HOME_DIR, "duck_config.json")
 
 dummy_config = DuckConfig(config_json_path=None, ignore_default=True)
 
@@ -77,7 +82,31 @@ try:
             print("===")
 
     print("Done ! ")
-    print("Now you can copy the offsets in your duck_config.json")
+    print("")
+    print("=== New offsets ===")
+    print(json.dumps({"joints_offsets": hwi.joints_offsets}, indent=2))
+    print("===================")
+    
+    # Update duck_config.json
+    save = input(f"\nSave to {DUCK_CONFIG_PATH}? (Y/n): ").lower()
+    if save == "y" or save == "":
+        # Load existing config or start with empty dict
+        if os.path.exists(DUCK_CONFIG_PATH):
+            with open(DUCK_CONFIG_PATH, "r") as f:
+                config = json.load(f)
+        else:
+            config = {}
+        
+        # Update only the joints_offsets key
+        config["joints_offsets"] = hwi.joints_offsets
+        
+        # Write back
+        with open(DUCK_CONFIG_PATH, "w") as f:
+            json.dump(config, f, indent=2)
+        
+        print(f"✓ Saved offsets to {DUCK_CONFIG_PATH}")
+    else:
+        print("Not saved. You can copy the JSON above manually.")
 
 
 except KeyboardInterrupt:


### PR DESCRIPTION
Here's how the script handles the JSON output and config file saving:

## Step 1: Print the JSON Object

```86:88:/Open_Duck_Mini_Runtime/scripts/find_soft_offsets.py
    print("=== New offsets ===")
    print(json.dumps({"joints_offsets": hwi.joints_offsets}, indent=2))
    print("===================")
```

After calibrating all joints, it prints the offsets as formatted JSON:

```json
=== New offsets ===
{
  "joints_offsets": {
    "right_hip_yaw": 0.05,
    "right_hip_roll": -0.02,
    "right_hip_pitch": 0.03,
    ...
  }
}
===================
```

The `indent=2` makes it human-readable with proper formatting.

---

## Step 2: Ask to Save

```91:92:/Open_Duck_Mini_Runtime/scripts/find_soft_offsets.py
    save = input(f"\nSave to {DUCK_CONFIG_PATH}? (Y/n): ").lower()
    if save == "y" or save == "":
```

Prompts the user: `Save to ~/duck_config.json? (Y/n):`

- Press **Enter** or **Y** → saves
- Press **N** → skips saving

---

## Step 3: Load Existing Config (if it exists)

```94:98:/Open_Duck_Mini_Runtime/scripts/find_soft_offsets.py
        if os.path.exists(DUCK_CONFIG_PATH):
            with open(DUCK_CONFIG_PATH, "r") as f:
                config = json.load(f)
        else:
            config = {}
```

**Key behavior:** It doesn't overwrite the entire file — it loads the existing config first. This preserves other settings like `eyes`, `speaker`, `antennas`, etc.

---

## Step 4: Update Only `joints_offsets`

```100:101:/Open_Duck_Mini_Runtime/scripts/find_soft_offsets.py
        # Update only the joints_offsets key
        config["joints_offsets"] = hwi.joints_offsets
```

Only the `joints_offsets` key is replaced. All other config values remain untouched.

---

## Step 5: Write Back

```103:107:/Open_Duck_Mini_Runtime/scripts/find_soft_offsets.py
        with open(DUCK_CONFIG_PATH, "w") as f:
            json.dump(config, f, indent=2)
        
        print(f"✓ Saved offsets to {DUCK_CONFIG_PATH}")
```

Writes the merged config back to the file with nice formatting.

---

## Visual Flow

```
┌─────────────────────────────────────────────────┐
│  Calibration complete                           │
└─────────────────────────────────────────────────┘
                    │
                    ▼
        ┌───────────────────────┐
        │  Print JSON to console │  ← Always happens
        │  (copy-paste backup)   │
        └───────────────────────┘
                    │
                    ▼
        ┌───────────────────────┐
        │  Save to config? (Y/n) │
        └───────────────────────┘
               │         │
          Y/Enter        N
               │         │
               ▼         ▼
    ┌─────────────────┐  "Not saved. You can
    │ Load existing   │   copy the JSON above
    │ duck_config.json│   manually."
    │       │         │
    │       ▼         │
    │ Merge offsets   │
    │       │         │
    │       ▼         │
    │ Write file      │
    │       │         │
    │       ▼         │
    │ "✓ Saved..."    │
    └─────────────────┘
```

---

## Why This Design?

1. **Always prints JSON** → You have a backup even if you don't save
2. **Confirms before writing** → Won't accidentally overwrite your config
3. **Merges, doesn't replace** → Preserves other config settings
4. **Default is Yes** → Pressing Enter saves (convenient for quick workflows)


## ⚠️ Why not write to the EEPROM of the servo?
- If you put offsets in a file, you always have:
  - Backups
  - Version history
  - Ability to reset to defaults instantly (for example when swapping a broken servo)
- Servo EEPROM usually supports ~100k writes (sometimes less).
Writing them repeatedly will degrade the EEPROM.